### PR TITLE
Update doku2md

### DIFF
--- a/doku2md
+++ b/doku2md
@@ -13,7 +13,7 @@
 
 # all we know is that coming from dokuwiki we get html. the rest is left 
 #  to the user
-pd_options="-f html -t markdown --strict"
+pd_options="-f html -t markdown_strict"
 
 #test for existence of required programs
 test_existence() {


### PR DESCRIPTION
The new version of pandoc doesn't accept anymore -t markdow --strict as on option but require to use -t markdown_strict instead
